### PR TITLE
MatJaz's new logic in TestNet only and .conf-urable and more

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -13,7 +13,6 @@
 
 #include "net.h"
 
-//using namespace std;
 using std::max;
 
 int CAddrInfo::GetTriedBucket(const std::vector<unsigned char> &nKey) const
@@ -706,3 +705,6 @@ void CAddrMan::Connected_(const CService &addr, int64_t nTime)
     if (nTime - info.nTime > nUpdateInterval)
         info.nTime = nTime;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -18,7 +18,6 @@
 #include "sync.h"
 #include "ui_interface.h"
 
-//using namespace std;
 using std::make_pair;
 using std::map;
 
@@ -253,3 +252,6 @@ bool CAlert::ProcessAlert()
     printf("accepted alert %d, AppliesToMe()=%d\n", nID, AppliesToMe());
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -62,7 +62,6 @@ using namespace boost;
 using namespace boost::asio;
 using namespace json_spirit;
 
-//using namespace std;
 using std::string;
 using std::list;
 using std::runtime_error;
@@ -82,7 +81,7 @@ void ThreadRPCServer3(void* parg);
 
 static inline unsigned short GetDefaultRPCPort()
 {
-    return GetBoolArg("-testnet", false)?7687 :17687;  // these are btc $s 18332 : 8332;
+    return GetBoolArg("-testnet", false)? 7687: 17687;
 }
 
 Object JSONRPCError(int code, const string& message)
@@ -294,8 +293,8 @@ static const CRPCCommand vRPCCommands[] =
     { "getblockcount",          &getblockcount,          true,   false },
 #ifdef WIN32
     { "getblockcountt",         &getcurrentblockandtime, true,   false },
-    { "getyacprice",            &getYACprice,            true,   false },
 #endif
+    { "getyacprice",            &getYACprice,            true,   false },
     { "getconnectioncount",     &getconnectioncount,     true,   false },
     { "getaddrmaninfo",         &getaddrmaninfo,         true,   false },
     { "getpeerinfo",            &getpeerinfo,            true,   false },
@@ -1435,3 +1434,6 @@ int main(int argc, char *argv[])
 #endif
 
 const CRPCTable tableRPC;
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -864,17 +864,31 @@ void ThreadRPCServer2(void* parg)
     {
         context.set_options(ssl::context::no_sslv2);
 
-        filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
-        if (!pathCertFile.is_complete()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
-        if (filesystem::exists(pathCertFile)) context.use_certificate_chain_file(pathCertFile.string());
-        else printf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string().c_str());
+        filesystem::path 
+            pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
 
-        filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
-        if (!pathPKFile.is_complete()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
-        if (filesystem::exists(pathPKFile)) context.use_private_key_file(pathPKFile.string(), ssl::context::pem);
-        else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
+        if (!pathCertFile.is_complete()) 
+            pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
+        if (filesystem::exists(pathCertFile)) 
+            context.use_certificate_chain_file(pathCertFile.string());
+        else 
+            printf("ThreadRPCServer ERROR: missing server certificate file %s\n", 
+                   pathCertFile.string().c_str()
+                  );
 
-        string strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
+        filesystem::path 
+            pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
+        if (!pathPKFile.is_complete()) 
+            pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
+        if (filesystem::exists(pathPKFile)) 
+            context.use_private_key_file(pathPKFile.string(), ssl::context::pem); // causes exceptions???
+        else 
+            printf("ThreadRPCServer ERROR: missing server private key file %s\n", 
+                   pathPKFile.string().c_str()
+                  );
+
+        string 
+            strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
         SSL_CTX_set_cipher_list(context.impl(), strCiphers.c_str());
     }
 

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -501,3 +501,6 @@ bool CSyncCheckpoint::ProcessSyncCheckpoint(CNode* pfrom)
     printf("ProcessSyncCheckpoint: sync-checkpoint at %s\n", hashCheckpoint.ToString().c_str());
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -128,3 +128,6 @@ bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned
         return false;
     return cKeyCrypter.Decrypt(vchCiphertext, *((CKeyingMaterial*)&vchPlaintext));
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -22,7 +22,6 @@
 
 using namespace boost;
 
-//using namespace std;
 using std::runtime_error;
 using std::stringstream;
 using std::string;
@@ -690,4 +689,6 @@ bool CAddrDB::Read(CAddrMan& addr)
 
     return true;
 }
-
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -33,7 +33,7 @@ bool fNewerOpenSSL = false; // for key.cpp's benefit
 
 
 using namespace boost;
-//using namespace std;  // testing this change
+
 using std::string;
 using std::max;
 using std::map;
@@ -397,6 +397,8 @@ std::string HelpMessage()
         "  -daemon                " + _("Run in the background as a daemon and accept commands") + "\n" +
 #endif
         "  -testnet               " + _("Use the test network") + "\n" +
+        "  -testnetNewLogic       " + _("Use the test network New Logic") + "\n" +
+        "  -testnetnewlogicblocknumber=<number> " + _("New Logic starting at block = <number>") + "\n" +
         "  -debug                 " + _("Output extra debugging information. Implies all other -debug* options") + "\n" +
         "  -debugnet              " + _("Output extra network debugging information") + "\n" +
         "  -logtimestamps         " + _("Prepend debug output with timestamp") + "\n" +
@@ -596,6 +598,8 @@ bool AppInit2()
     else
         fDebugNet = GetBoolArg("-debugnet");
 
+    fTestNetNewLogic = GetBoolArg("-testnetNewLogic");
+
     bitdb.SetDetach(GetBoolArg("-detachdb", false));
 
 #if !defined(WIN32) && !defined(QT_GUI)
@@ -649,20 +653,45 @@ bool AppInit2()
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
-    std::string strDataDir = GetDataDir().string();
+    std::string 
+        strDataDir = GetDataDir().string();
+
     strWalletFileName = GetArg("-wallet", "wallet.dat");
 
     // strWalletFileName must be a plain filename without a directory
-    if (strWalletFileName != boost::filesystem::basename(strWalletFileName) + boost::filesystem::extension(strWalletFileName))
-        return InitError(strprintf(_("Wallet %s resides outside data directory %s."), strWalletFileName.c_str(), strDataDir.c_str()));
+    if (
+        strWalletFileName != 
+        boost::filesystem::basename(strWalletFileName) + 
+        boost::filesystem::extension(strWalletFileName)
+       )
+        return InitError(
+                         strprintf(
+                            _("Wallet %s resides outside data directory %s."), 
+                            strWalletFileName.c_str(), 
+                            strDataDir.c_str()
+                                  )
+                        );
 
     // Make sure only a single Bitcoin process is using the data directory.
-    boost::filesystem::path pathLockFile = GetDataDir() / ".lock";
-    FILE* file = fopen(pathLockFile.string().c_str(), "a"); // empty lock file; created if it doesn't exist.
-    if (file) fclose(file);
-    static boost::interprocess::file_lock lock(pathLockFile.string().c_str());
+    boost::filesystem::path 
+        pathLockFile = GetDataDir() / ".lock";
+
+    FILE
+        * file = fopen(pathLockFile.string().c_str(), "a"); // empty lock file; created if it doesn't exist.
+
+    if (file)         
+        fclose(file);
+
+    static boost::interprocess::file_lock 
+        lock(pathLockFile.string().c_str());
+
     if (!lock.try_lock())
-        return InitError(strprintf(_("Cannot obtain a lock on data directory %s.  Yacoin is probably already running."), strDataDir.c_str()));
+        return InitError(
+                         strprintf(
+                            _("Cannot obtain a lock on data directory %s.  Yacoin is probably already running."), 
+                            strDataDir.c_str()
+                                  )
+                        );
 
 #if !defined(WIN32) && !defined(QT_GUI)
     if (fDaemon)
@@ -691,6 +720,10 @@ bool AppInit2()
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Yacoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
 
+    if (fDebug)
+    {
+        (void)printf( "new logic flag is %s\n", fTestNetNewLogic? "true": "false" );
+    }
     printf("\n" );
     printf("Using Boost version %1d.%d.%d\n",         // miiill (most, insignificant, least) digits
             BOOST_VERSION / 100000,
@@ -766,6 +799,19 @@ bool AppInit2()
     printf("\n");
 
     printf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+
+    if (fDebug)
+    {
+    #ifdef WIN32
+        (void)printf(
+                     "\n"
+                     "wallet is \n"
+                     "\"%s\""
+                     "\n"
+                     , (strDataDir + "/" + strWalletFileName).c_str()
+                    );
+    #endif
+    }
 
     unsigned int
         nCutoffVersion = (unsigned int)((int)'j' - (int)'`'),
@@ -1042,7 +1088,8 @@ bool AppInit2()
 
     printf("Loading block index...\n");
     bool fLoaded = false;
-    while (!fLoaded) {
+    while (!fLoaded) 
+    {
         std::string strLoadError;
         // YACOIN TODO ADD SPINNER OR PROGRESS BAR
         uiInterface.InitMessage(_("<b>Loading block index, this may take several minutes...</b>"));
@@ -1052,11 +1099,13 @@ bool AppInit2()
             try {
                 UnloadBlockIndex();
 
-                if (!LoadBlockIndex()) {
+                if (!LoadBlockIndex()) 
+                {
                     strLoadError = _("Error loading block database");
                     break;
                 }
-            } catch(std::exception &e) {
+            } catch(std::exception &e) 
+            {
                 (void)e;
                 strLoadError = _("Error opening block database");
                 break;
@@ -1065,7 +1114,8 @@ bool AppInit2()
             fLoaded = true;
         } while(false);
 
-        if (!fLoaded) {
+        if (!fLoaded) 
+        {
             // TODO: suggest reindex here
             return InitError(strLoadError);
         }
@@ -1080,6 +1130,24 @@ bool AppInit2()
         return false;
     }
     printf(" block index %15" PRId64 "ms\n", GetTimeMillis() - nStart);
+
+    nTestNetNewLogicBlockNumber = GetArg("-testnetnewlogicblocknumber", 0);
+    if (0 == nTestNetNewLogicBlockNumber)
+        nTestNetNewLogicBlockNumber = pindexBest->nHeight;
+    if (fDebug)
+    {
+    #ifdef WIN32
+        (void)printf(
+                     "\n"
+                     "nTestNetNewLogicBlockNumber is \n"
+                     "%d"
+                     "\n"
+                     , nTestNetNewLogicBlockNumber
+                    );
+    #endif
+    }
+
+    (void)HaveWeSwitchedToNewLogicRules( fUseOld044Rules );
 
     if (GetBoolArg("-printblockindex") || GetBoolArg("-printblocktree"))
     {
@@ -1294,3 +1362,6 @@ bool AppInit2()
 #endif
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -406,22 +406,21 @@ std::string HelpMessage()
         "  -printtoconsole        " + _("Send trace/debug info to console instead of debug.log file") + "\n" +
 #ifdef WIN32
         "  -printtodebugger       " + _("Send trace/debug info to debugger") + "\n" +
-
-        "  -btcyacprovider        " + _("Add a BTC to YAC price provider, entered as") + "\n" +
-     + ("                         domain,key,argument,offset") + "\n" +
-     + ("                         For example: where the url is") + "\n" +
-     + ("                         http://pubapi2.cryptsy.com/api.php?method=singlemarketdata&marketid=11") + "\n" +
-     + ("                         one would enter") + "\n" +
-     + ("                         pubapi2.cryptsy.com,lasttradeprice,/api.php?method=singlemarketdata&marketid=11,3") + "\n" +
-     + ("                         see https://www.cryptsy.com/pages/publicapi") + "\n" +
-        "  -usdbtcprovider        " + _("Add a USD to BTC price provider, entered as") + "\n" +
-     + ("                         domain,key,argument,offset") + "\n" +
-     + ("                         For example: where the url is") + "\n" +
-     + ("                         http://pubapi2.cryptsy.com/api.php?method=singlemarketdata&marketid=2") + "\n" +
-     + ("                         one would enter") + "\n" +
-     + ("                         pubapi2.cryptsy.com,lastdata,/api.php?method=singlemarketdata&marketid=2,3") + "\n" +
-     + ("                         see https://www.cryptsy.com/pages/publicapi") + "\n" +
 #endif
+        "  -btcyacprovider        " + _("Add a BTC to YAC price provider, entered as") + "\n" +
+        "                         domain,key,argument,offset,port" + "\n" 
+        "                         For example: where the url is" + "\n"
+        "                         http://pubapi2.cryptsy.com/api.php?method=singlemarketdata&marketid=11" + "\n"
+        "                         one would enter" + "\n"
+        "                         pubapi2.cryptsy.com,lasttradeprice,/api.php?method=singlemarketdata&marketid=11,3,80" + "\n"
+        "                         see https://www.cryptsy.com/pages/publicapi" + "\n" +
+        "  -usdbtcprovider        " + _("Add a USD to BTC price provider, entered as") + "\n" +
+        "                         domain,key,argument,offset" + "\n" +
+        "                         For example: where the url is" + "\n" +
+        "                         http://pubapi2.cryptsy.com/api.php?method=singlemarketdata&marketid=2" + "\n" +
+        "                         one would enter" + "\n" +
+        "                         pubapi2.cryptsy.com,lastdata,/api.php?method=singlemarketdata&marketid=2,3,80" + "\n" +
+        "                         see https://www.cryptsy.com/pages/publicapi" + "\n" +
         "  -rpcuser=<user>        " + _("Username for JSON-RPC connections") + "\n" +
         "  -rpcpassword=<pw>      " + _("Password for JSON-RPC connections") + "\n" +
         "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 7687 or testnet: 17687)") + "\n" +
@@ -1090,13 +1089,16 @@ bool AppInit2()
     bool fLoaded = false;
     while (!fLoaded) 
     {
-        std::string strLoadError;
+        std::string 
+            strLoadError;
         // YACOIN TODO ADD SPINNER OR PROGRESS BAR
         uiInterface.InitMessage(_("<b>Loading block index, this may take several minutes...</b>"));
 
         nStart = GetTimeMillis();
-        do {
-            try {
+        do 
+        {
+            try 
+            {
                 UnloadBlockIndex();
 
                 if (!LoadBlockIndex()) 
@@ -1104,19 +1106,19 @@ bool AppInit2()
                     strLoadError = _("Error loading block database");
                     break;
                 }
-            } catch(std::exception &e) 
+            } 
+            catch(std::exception &e) 
             {
                 (void)e;
                 strLoadError = _("Error opening block database");
                 break;
             }
-
             fLoaded = true;
-        } while(false);
+        }
+        while(false);
 
         if (!fLoaded) 
-        {
-            // TODO: suggest reindex here
+        {   // TODO: suggest reindex here
             return InitError(strLoadError);
         }
     }

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -15,7 +15,6 @@
 
 using namespace boost;
 
-//using namespace std;
 using std::string;
 using std::vector;
 
@@ -213,6 +212,8 @@ void ThreadIRCSeed(void* parg)
 
 void ThreadIRCSeed2(void* parg)
 {
+//    LOCK(cs_net);
+    {
     // Don't connect to IRC if we won't use IPv4 connections.
     if (IsLimited(NET_IPV4))
         return;
@@ -384,16 +385,8 @@ void ThreadIRCSeed2(void* parg)
         if (!Wait(nRetryWait += 60))
             return;
     }
+    }
 }
-
-
-
-
-
-
-
-
-
 
 #ifdef TEST
 int main(int argc, char *argv[])
@@ -410,4 +403,7 @@ int main(int argc, char *argv[])
     WSACleanup();
     return 0;
 }
+#endif
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
 #endif

--- a/src/json/json_spirit_writer.cpp
+++ b/src/json/json_spirit_writer.cpp
@@ -98,3 +98,6 @@ std::wstring json_spirit::write_formatted( const wmValue&  value )
 }
 
 #endif
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -14,7 +14,6 @@
 #include "txdb.h"
 #include "timestamps.h"
 
-//using namespace std;
 using std::min;
 using std::vector;
 using std::pair;
@@ -402,7 +401,8 @@ uint256 GetProofOfStakeHash(
     uint256 thash;
 
     if (
-        (nTimeTx >= YACOIN_2016_SWITCH_TIME) 
+        !fUseOld044Rules
+    //(nTimeTx >= YACOIN_NEW_LOGIC_SWITCH_TIME) 
     //    || fTestNet   // to do testnet always the new way
     //    && !fTestNet  // to do testnet the old way
        )
@@ -901,3 +901,6 @@ bool CheckStakeModifierCheckpoints(int nHeight, uint32_t nStakeModifierChecksum)
         return nStakeModifierChecksum == checkpoints[nHeight];
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -9,7 +9,6 @@
 #include "wallet.h"
 #include "base58.h"
 
-//using namespace std;  // testing this change
 using std::vector;
 using std::max;
 using std::min;
@@ -146,3 +145,6 @@ double KernelRecord::getProbToMintWithinNMinutes(double difficulty, int minutes)
     }
     return prevProbability;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -592,3 +592,6 @@ bool CKey::IsValid()
     key2.SetSecret(secret, fCompr);
     return GetPubKey() == key2.GetPubKey();
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -312,3 +312,6 @@ bool CCryptoKeyStore::DecryptKeys(const CKeyingMaterial& vMasterKeyIn)
 
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1121,7 +1121,10 @@ uint256 WantedByOrphan(const CBlock* pblockOrphan)
 
 // yacoin: increasing Nfactor gradually
 const unsigned char minNfactor = 4;
-const unsigned char maxNfactor = 30;
+const unsigned char maxNfactor = MAXIMUM_N_FACTOR;
+                                        //30; since uint32_t fails on 07 Feb 2106 06:28:15 GMT
+                                        //    when stored as an uint32_t in a block
+                                        //    so there is no point going past Nf = 25
 
 unsigned char GetNfactor(::int64_t nTimestamp) 
 {

--- a/src/main.h
+++ b/src/main.h
@@ -47,6 +47,10 @@ static const ::int64_t MAX_MINT_PROOF_OF_WORK = 100 * COIN;
 static const ::int64_t MAX_MINT_PROOF_OF_STAKE = 1 * COIN;
 static const ::int64_t MIN_TXOUT_AMOUNT = CENT/100;
 
+static const unsigned char MAXIMUM_N_FACTOR = 25;  //30; since uint32_t fails on 07 Feb 2106 06:28:15 GMT
+                                                   //    when stored as an uint32_t in a block
+                                                   //    so there is no point going past Nf = 25
+
 inline bool MoneyRange(::int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 // Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
@@ -988,28 +992,41 @@ public:
     // yacoin2015 update
     uint256 GetHash() const
     {
-        const ::uint32_t
-            nSpanOf4  = 1368515488 - nChainStartTime,
-            nSpanOf5  = 1368777632 - nChainStartTime,
-            nSpanOf6  = 1369039776 - nChainStartTime,
-            nSpanOf7  = 1369826208 - nChainStartTime,
-            nSpanOf8  = 1370088352 - nChainStartTime,
-            nSpanOf9  = 1372185504 - nChainStartTime,
-            nSpanOf10 = 1373234080 - nChainStartTime,
-            nSpanOf11 = 1376379808 - nChainStartTime,
-            nSpanOf12 = 1380574112 - nChainStartTime,
-            nSpanOf13 = 1384768416 - nChainStartTime,
-            nSpanOf14 = 1401545632 - nChainStartTime,
-            nSpanOf15 = 1409934240 - nChainStartTime,
-            nSpanOf16 = 1435100064 - nChainStartTime,
-            nSpanOf17 = 1468654496 - nChainStartTime,
-            nSpanOf18 = 1502208928 - nChainStartTime;   // 8/8/17 16:15GMT
+        const ::uint64_t
+            nSpanOf4  = 1368515488 - nChainStartTime,                           
+            nSpanOf5  = 1368777632 - nChainStartTime,                           
+            nSpanOf6  = 1369039776 - nChainStartTime,                           
+            nSpanOf7  = 1369826208 - nChainStartTime,                           
+            nSpanOf8  = 1370088352 - nChainStartTime,                           
+            nSpanOf9  = 1372185504 - nChainStartTime,                           
+            nSpanOf10 = 1373234080 - nChainStartTime,                           
+            nSpanOf11 = 1376379808 - nChainStartTime,                           
+            nSpanOf12 = 1380574112 - nChainStartTime,   // Mon, 30 Sep 2013 20:48:32 GMT                        
+            nSpanOf13 = 1384768416 - nChainStartTime,   // Mon, 18 Nov 2013 09:53:36 GMT                    
+            nSpanOf14 = 1401545632 - nChainStartTime,   // Sat, 31 May 2014 14:13:52 GMT                    
+            nSpanOf15 = 1409934240 - nChainStartTime,   // Fri, 05 Sep 2014 16:24:00 GMT (Nf) 16
+            nSpanOf16 = 1435100064 - nChainStartTime,   // Tue, 23 Jun 2015 22:54:24 GMT (Nf) 17
+            nSpanOf17 = 1468654496 - nChainStartTime,   // Sat, 16 Jul 2016 07:34:56 GMT (Nf) 18
+            nSpanOf18 = 1502208928 - nChainStartTime,   // Tue, 08 Aug 2017 16:15:28 GMT (Nf) 19
+            nSpanOf19 = 1602872224 - nChainStartTime,   // Fri, 16 Oct 2020 18:17:04 GMT                        
+            nSpanOf20 = 1636426656 - nChainStartTime,   // Tue, 09 Nov 2021 02:57:36 GMT                        
+            nSpanOf21 = 1904862112 - nChainStartTime,   // Mon, 13 May 2030 00:21:52 GMT                        
+            nSpanOf22 = 2173297568 - nChainStartTime,   // Sat, 13 Nov 2038 21:46:08 GMT                        
+            nSpanOf23 = 2441733024 - nChainStartTime,   // Fri, 17 May 2047 19:10:24 GMT                        
+            nSpanOf24 = 3247039392 - nChainStartTime,   // Tue, 22 Nov 2072 11:23:12 GMT                        
+            nSpanOf25 = 3515474848 - nChainStartTime;   // Mon, 26 May 2081 08:47:28 GMT                        
+            // uint_32 fails here                          Sun, 07 Feb 2106 06:28:15 GMT
+          //nSpanOf26 = 5662958496 - nChainStartTime,   // Sat, 14 Jun 2149 12:01:36 GMT                       
+          //nSpanOf27 = 6736700320 - nChainStartTime,   // Tue, 24 Jun 2183 01:38:40 GMT                        
+          //nSpanOf28 = 9957925792 - nChainStartTime,   // Tue, 21 Jul 2285 18:29:52 GMT                        
+          //nSpanOf29 = 14252893088 - nChainStartTime,  // Sat, 28 Aug 2421 00:58:08 GMT
+          //nSpanOf30 = 18547860384 - nChainStartTime;  // Tue, 04 Oct 2557 07:26:24 GMT
 
         unsigned char 
             nfactor;
-        if( !fTestNet )   //<<<<<<<<<<<<<<<<<<<<<<<<< test!!!
+        if( !fTestNet )
         {     // nChainStartTime = 1367991200 is start
-		    if ( nTime < (nChainStartTime + nSpanOf4 ) ) nfactor = 4;
+		    if      ( nTime < (nChainStartTime + nSpanOf4 ) ) nfactor = 4;
             else if ( nTime < (nChainStartTime + nSpanOf5 ) ) nfactor = 5;
             else if ( nTime < (nChainStartTime + nSpanOf6 ) ) nfactor = 6;
             else if ( nTime < (nChainStartTime + nSpanOf7 ) ) nfactor = 7;
@@ -1024,25 +1041,21 @@ public:
             else if ( nTime < (nChainStartTime + nSpanOf16) ) nfactor = 16;
             else if ( nTime < (nChainStartTime + nSpanOf17) ) nfactor = 17;
             else if ( nTime < (nChainStartTime + nSpanOf18) ) nfactor = 18;
-/***********************************
-            if ( nTime < 1368515488 ) nfactor = 4;
-    		else if ( nTime < 1368777632 ) nfactor = 5;
-	    	else if ( nTime < 1369039776 ) nfactor = 6;
-		    else if ( nTime < 1369826208 ) nfactor = 7;
-    		else if ( nTime < 1370088352 ) nfactor = 8;
-	    	else if ( nTime < 1372185504 ) nfactor = 9;
-		    else if ( nTime < 1373234080 ) nfactor = 10;
-    		else if ( nTime < 1376379808 ) nfactor = 11;
-	    	else if ( nTime < 1380574112 ) nfactor = 12;
-		    else if ( nTime < 1384768416 ) nfactor = 13;
-    		else if ( nTime < 1401545632 ) nfactor = 14;
-	    	else if ( nTime < 1409934240 ) nfactor = 15;
-		    else if ( nTime < 1435100064 ) nfactor = 16;
-		    else if ( nTime < 1468654496 ) nfactor = 17;	// as soon as possible
-**************************************/
-    		else
-              //nfactor = 4;
-                nfactor = 19;
+            else if ( nTime < (nChainStartTime + nSpanOf19) ) nfactor = 19;
+            else if ( nTime < (nChainStartTime + nSpanOf20) ) nfactor = 20;
+            else if ( nTime < (nChainStartTime + nSpanOf21) ) nfactor = 21;
+            else if ( nTime < (nChainStartTime + nSpanOf22) ) nfactor = 22;
+            else if ( nTime < (nChainStartTime + nSpanOf23) ) nfactor = 23;
+            else if ( nTime < (nChainStartTime + nSpanOf24) ) nfactor = 24;
+            else if ( nTime < (nChainStartTime + nSpanOf25) ) nfactor = 25;
+          //  else if ( nTime < (nChainStartTime + nSpanOf26) ) nfactor = 26;
+            // uint_32 fails here
+          //  else if ( nTime < (nChainStartTime + nSpanOf27) ) nfactor = 27;
+          //  else if ( nTime < (nChainStartTime + nSpanOf28) ) nfactor = 28;
+          //  else if ( nTime < (nChainStartTime + nSpanOf29) ) nfactor = 29;
+          //  else if ( nTime < (nChainStartTime + nSpanOf30) ) nfactor = 30;
+            else
+                nfactor = MAXIMUM_N_FACTOR;
         }
         else
         {

--- a/src/main.h
+++ b/src/main.h
@@ -1022,7 +1022,6 @@ public:
             else if ( nTime < (nChainStartTime + nSpanOf14) ) nfactor = 14;
             else if ( nTime < (nChainStartTime + nSpanOf15) ) nfactor = 15;
             else if ( nTime < (nChainStartTime + nSpanOf16) ) nfactor = 16;
-          //else if ( nTime < YACOIN_2016_SWITCH_TIME ) nfactor = 17;    // as soon as possible
             else if ( nTime < (nChainStartTime + nSpanOf17) ) nfactor = 17;
             else if ( nTime < (nChainStartTime + nSpanOf18) ) nfactor = 18;
 /***********************************
@@ -1039,7 +1038,6 @@ public:
     		else if ( nTime < 1401545632 ) nfactor = 14;
 	    	else if ( nTime < 1409934240 ) nfactor = 15;
 		    else if ( nTime < 1435100064 ) nfactor = 16;
-    	  //else if ( nTime < YACOIN_2016_SWITCH_TIME ) nfactor = 17;	// as soon as possible
 		    else if ( nTime < 1468654496 ) nfactor = 17;	// as soon as possible
 **************************************/
     		else

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -16,7 +16,6 @@
 #include "init.h"
 #include "scrypt.h"
 
-//using namespace std;
 using std::vector;
 using std::set;
 using std::list;
@@ -134,7 +133,7 @@ public:
     {
         if(
             false 
-            //((pindexBest->nTime < YACOIN_2016_SWITCH_TIME) && !fTestNet )
+            //((pindexBest->nTime < YACOIN_NEW_LOGIC_SWITCH_TIME) && !fTestNet )
           )
         {
             SetMockTime( (int64_t)(pindexBest->nTime + nOneMinuteInSeconds) );
@@ -145,7 +144,7 @@ public:
     {
         if(
             false 
-            //((pindexBest->nTime < YACOIN_2016_SWITCH_TIME) && !fTestNet )
+            //((pindexBest->nTime < YACOIN_NEW_LOGIC_SWITCH_TIME) && !fTestNet )
           )
         {
             SetMockTime( 0 );   // restores time to now
@@ -251,8 +250,6 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
                 fCreatedCoinStake;
             if(
                 fUseOld044Rules
-                //fTestNet || // test to see if one can mint in TestNet
-                //((pindexBest->nTime < YACOIN_2016_SWITCH_TIME) && !fTestNet)
               )
             {
                 fCreatedCoinStake = pwallet->CreateCoinStake(
@@ -297,8 +294,6 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
 
     if(
         fUseOld044Rules
-        //fTestNet || // test to see if one can mint in TestNet
-        //((pindexBest->nTime < YACOIN_2016_SWITCH_TIME) && !fTestNet)
       )
     {   // Collect memory pool transactions into the block
         ::int64_t 
@@ -1017,7 +1012,12 @@ void StakeMinter(CWallet *pwallet)
         }
 
         while (
-               IsInitialBlockDownload() || vNodes.empty()
+               IsInitialBlockDownload() ||
+               (
+                vNodes.empty() 
+                //&& !fTestNet      //TestNet can mint stand alone!
+               )
+               //|| (fTestNet && (pindexBest->nHeight < nCoinbaseMaturity))
               )
         {
             Sleep(1000);
@@ -1115,7 +1115,11 @@ static void YacoinMiner(CWallet *pwallet)  // here fProofOfStake is always false
         if (fShutdown)
             return;
         while (
-               IsInitialBlockDownload() || vNodes.empty()
+               IsInitialBlockDownload() || 
+               (
+                vNodes.empty() 
+                //&& !fTestNet               //TestNet can mine stand alone!
+               )
               )
         {
             //printf("vNodes.size() == %d, IsInitialBlockDownload() == %d\n", vNodes.size(), IsInitialBlockDownload());
@@ -1314,7 +1318,7 @@ static void YacoinMiner(CWallet *pwallet)  // here fProofOfStake is always false
                 (pindexPrev != pindexBest) ||
                 (!fGenerateBitcoins) ||
                 fShutdown ||
-                vNodes.empty()
+                (vNodes.empty() && !fTestNet)
                )
                 break;
 
@@ -1415,3 +1419,6 @@ void GenerateYacoins(bool fGenerate, CWallet* pwallet)
 }
 //_____________________________________________________________________________
 //_____________________________________________________________________________
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -360,7 +360,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
                             }
 #else
                             {
-                                assert("mempool transaction missing input" == 0);
+                                //assert("mempool transaction missing input" == 0);
                             }
                         // does the if() above execute the next statement in release mode???
                         // gcc or MS.  Is this wrong?? Intended??  Should it?? Is the assert()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1956,10 +1956,6 @@ void ThreadDumpAddress2(void* parg)
     {
         DumpAddresses();
         --vnThreadsRunning[THREAD_DUMPADDRESS];
-      //Sleep(600000);  // why wait 10 minutes?????
-      //Sleep(600 * nMillisecondsPerSecond);
-      //Sleep(10 * nSecondsperMinute * nMillisecondsPerSecond); // these 3 above are all the same
-                                                                // which is clearer?
         Sleep(1 * nSecondsperMinute * nMillisecondsPerSecond);  // try this arbitrary value
         ++vnThreadsRunning[THREAD_DUMPADDRESS];
     }
@@ -2311,13 +2307,12 @@ void ThreadOpenAddedConnections2(void* parg)
           //Sleep(120000); // Retry every 2 minutes
                             // why??? Is this related to any other magic #?????????????????????????
             Sleep(2 * nSecondsperMinute * nMillisecondsPerSecond);
-            //Sleep(90 * nMillisecondsPerSecond); // Retry every 1.5 minutes
             ++vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
         }
         return;
     }
 
-    for (::uint32_t i = 0; true; ++i)
+    for (::uint32_t i = 0; true; ++i)   // for ever
     {
         list<string> lAddresses(0);
         {
@@ -2397,9 +2392,8 @@ void ThreadOpenAddedConnections2(void* parg)
             fConnected = OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
             if (!fShutdown)
             {
-              //Sleep(500); // longer?????????????????
-                Sleep(5 * nOneHundredMilliseconds);
-                //Sleep(10 * nMillisecondsPerSecond);
+              //Sleep(6 * nMillisecondsPerSecond);  // is this related to nConnectTimeout?
+                Sleep( nConnectTimeout );  // just trying to get rid of these magic #s
             }
             else
             {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -31,7 +31,6 @@
 
 using namespace boost;
 
-//using namespace std;
 using std::map;
 using std::string;
 using std::runtime_error;
@@ -561,26 +560,28 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, ::int64_t nTimeout
 
 
     /// debug print
-    printf( "trying connection " );
-    if( pszDest )
+    if (fDebug)
     {
-        printf( "%s\n", pszDest );
+        printf( "trying connection " );
+        if( pszDest )
+        {
+            printf( "%s\n", pszDest );
+        }
+        else
+        {
+            printf( "%s\n", 
+                strprintf( " %s, last seen = %s",
+                           addrConnect.ToString().c_str(),
+                           ((double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24)?
+                           "days":
+                           strprintf( "%.1lfhrs", 
+                                      (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0
+                                    ).c_str()
+                         ).c_str()
+                  );
+            //printf( "%s lastseen=%.1fhrs\n", addrConnect.ToString().c_str(), (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24 );
+        }
     }
-    else
-    {
-        printf( "%s\n", 
-            strprintf( " %s, last seen = %s",
-                       addrConnect.ToString().c_str(),
-                       ((double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24)?
-                       "days":
-                       strprintf( "%.1lfhrs", 
-                                  (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0
-                                ).c_str()
-                     ).c_str()
-              );
-        //printf( "%s lastseen=%.1fhrs\n", addrConnect.ToString().c_str(), (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24 );
-    }
-
     // Connect
     SOCKET hSocket;
     if (
@@ -691,7 +692,7 @@ void CNode::CloseSocketDisconnect()
                 case WSAENETDOWN:
                     //The network subsystem has failed.
 
-                case WSAENOTSOCK:
+                case WSAENOTSOCK:   //<<<<<<<<<<
                     //The descriptor is not a socket.
 
                 case WSAEINPROGRESS:
@@ -1385,7 +1386,7 @@ void ThreadSocketHandler2(void* parg)
                                                     //this error indicates that the time to live 
                                                     //has expired.
 
-                                                case WSAENOTSOCK:
+                                                case WSAENOTSOCK:   //<<<<<<<<
                                                     //The descriptor is not a socket.
 
                                                 case WSAEOPNOTSUPP:
@@ -1464,7 +1465,7 @@ void ThreadSocketHandler2(void* parg)
                                                     //this error indicates that the time to live 
                                                     //has expired.
 
-                                    WSAENOTSOCK     //The descriptor is not a socket.
+                                    WSAENOTSOCK     //The descriptor is not a socket. <<<<<<<<<<<
 
                                     WSAEOPNOTSUPP   //MSG_OOB was specified, but the socket 
                                                     //is not stream-style such as type SOCK_STREAM, 
@@ -2619,13 +2620,20 @@ void ThreadMessageHandler2(void* parg)
 
 bool BindListenPort(const CService &addrBind, string& strError)
 {
+//    LOCK(cs_net);
+    {
     strError = "";
-    int nOne = 1;
+    u_long
+        nOne = 1;
 
 #ifdef WIN32
     // Initialize Windows Sockets
-    WSADATA wsadata;
-    int ret = WSAStartup(MAKEWORD(2,2), &wsadata);
+    WSADATA 
+        wsadata;
+
+    int 
+        ret = WSAStartup(MAKEWORD(2,2), &wsadata);
+
     if (ret != NO_ERROR)
     {
         strError = strprintf("Error: TCP/IP socket library failed to start (WSAStartup returned error %d)", ret);
@@ -2675,7 +2683,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
 
 #ifdef WIN32
     // Set to non-blocking, incoming connections will also inherit this
-    if (ioctlsocket(hListenSocket, FIONBIO, (u_long*)&nOne) == SOCKET_ERROR)
+    if (ioctlsocket(hListenSocket, FIONBIO, &nOne) == SOCKET_ERROR)
 #else
     if (fcntl(hListenSocket, F_SETFL, O_NONBLOCK) == SOCKET_ERROR)
 #endif
@@ -2691,7 +2699,8 @@ bool BindListenPort(const CService &addrBind, string& strError)
 #ifdef USE_IPV6
     // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
     // and enable it by default or not. Try to enable it, if possible.
-    if (addrBind.IsIPv6()) {
+    if (addrBind.IsIPv6()) 
+    {
 #ifdef IPV6_V6ONLY
 #ifdef WIN32
         setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&nOne, sizeof(int));
@@ -2746,6 +2755,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
 
     printf("Socket %s initialized\n",  addrBind.ToString().c_str());
     return true;
+    }
 }
 
 void static Discover()
@@ -3073,3 +3083,6 @@ void CNode::RecordBytesSent(::uint64_t bytes)
     LOCK(cs_totalBytesSent);
     return nTotalBytesSent;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/net.h
+++ b/src/net.h
@@ -70,7 +70,7 @@ inline ::uint64_t SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000
 
 void AddOneShot(std::string strDest);
 bool RecvLine(SOCKET hSocket, std::string& strLine);
-#ifdef WIN32
+//#ifdef WIN32
     class CProvider
     {
     public:
@@ -80,12 +80,12 @@ bool RecvLine(SOCKET hSocket, std::string& strLine);
             sApi;
         int
             nOffset;
-        static const int
+        //static const int
             //nOffset = DEFAULT_char_offset,
-            nPort = DEFAULT_HTTP_PORT;
-        //int
+        //    nPort = DEFAULT_HTTP_PORT;
+        int
         //    nOffset;
-        //    nPort,
+            nPort;
     };
     extern std::vector< CProvider > vBTCtoYACProviders;
     extern std::vector< CProvider > vUSDtoBTCProviders;
@@ -93,7 +93,7 @@ bool RecvLine(SOCKET hSocket, std::string& strLine);
     extern void initialize_price_vectors( int & nIndexBtcToYac, int & nIndexUsdToBtc );
     extern bool GetMyExternalWebPage1( int & nIndex, std::string & strBuffer, double & dPrice );
     extern bool GetMyExternalWebPage2( int & nIndex, std::string & strBuffer, double & dPrice );
-#endif
+//#endif
 bool GetMyExternalIP(CNetAddr& ipRet);
 void AddressCurrentlyConnected(const CService& addr);
 //CNode* FindNode(const CNetAddr& ip);

--- a/src/net.h
+++ b/src/net.h
@@ -13,6 +13,7 @@
 #include <openssl/rand.h>
 
 #ifdef _MSC_VER
+    #include <stdint.h>
     #include "JustInCase.h"
 #endif
 #ifndef WIN32
@@ -29,6 +30,8 @@ class CRequestTracker;
 class CNode;
 class CBlockIndex;
 extern int nBestHeight;
+
+//extern CCriticalSection cs_net;
 
 const ::int64_t
     nSecondsPerMinute = 60,

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -32,3 +32,6 @@ void noui_connect()
     uiInterface.ThreadSafeMessageBox.connect(noui_ThreadSafeMessageBox);
     uiInterface.ThreadSafeAskFee.connect(noui_ThreadSafeAskFee);
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -162,4 +162,6 @@ void CInv::print() const
 {
     printf("CInv(%s)\n", ToString().c_str());
 }
-
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -500,10 +500,10 @@ void BitcoinGUI::createMenuBar()
     help->addSeparator();
     //_________________________________________________________________________
     // remove this WIN32 conditional to test the code on the Mac & linux, etc.
-#ifdef WIN32
+//#ifdef WIN32
     help->addAction(explorerAction);
     help->addSeparator();
-#endif
+//#endif
     help->addAction(aboutAction);
     help->addAction(aboutQtAction);
 }

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -44,7 +44,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Execute command when the best block changes (%s in cmd is replaced by block "
 "hash)"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Listen for JSON-RPC connections on <port> (default: 8332 or testnet: 18332)"),
+"Listen for JSON-RPC connections on <port> (default: 7687 or testnet: 17687)"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Number of seconds to keep misbehaving peers from reconnecting (default: "
 "86400)"),

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -106,11 +106,21 @@ public:
             bool 
                 showTransaction;
             // Determine whether to show transaction or not
-            if( mi->second.nTimeReceived < YACOIN_2016_SWITCH_TIME )
-            {
-                showTransaction = (inWallet && TransactionRecord::showTransaction(mi->second, false));
-            }
-            else
+
+            // Again I don't understand what is the intent? Why is this needed for YAC??
+            // It seems to be the reverse of what it is calling?
+            // It seems the one call should be sufficient?  Or am I missing some 
+            // again undocumented (here) information???
+            // so shouldn't this be
+            //if( 
+            //   (mi->second.nTimeReceived < YACOIN_NEW_LOGIC_SWITCH_TIME) 
+            //   && 
+            //   !fTestNet 
+            //  )
+            //{
+            //    showTransaction = (inWallet && TransactionRecord::showTransaction(mi->second, false));
+            //}
+            //else
             {
                 showTransaction = (inWallet && TransactionRecord::showTransaction(mi->second));
             }
@@ -426,6 +436,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
+    case TransactionRecord::Mined:          //<<<<<<<<<<<<<<test
         return lookupAddress(wtx->address, tooltip);
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address);
@@ -442,6 +453,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     {
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
+    case TransactionRecord::Mined:          //<<<<<<<<<<<<<<<test
     case TransactionRecord::Generated:
         {
         QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
@@ -641,7 +653,11 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         // Return True if transaction counts for balance
         return rec->status.confirmed && 
                 !(
-                  (rec->type == TransactionRecord::Generated) && 
+                  (
+                   (rec->type == TransactionRecord::Generated)
+                   || (rec->type == TransactionRecord::Mined)   //<<<<<<<<<<<<<<<< test
+                   )
+                  && 
                   (rec->status.maturity != TransactionStatus::Mature)
                  );
     case FormattedAmountRole:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -79,7 +79,8 @@ TransactionView::TransactionView(QWidget *parent) :
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
-    typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Mined));
+    typeWidget->addItem(tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -11,7 +11,6 @@
 
 using namespace json_spirit;
 
-//using namespace std;  // testing this change
 using std::max;
 using std::string;
 using std::runtime_error;
@@ -175,8 +174,6 @@ Value getblockcount(const Array& params, bool fHelp)
     return nBestHeight;
 }
 
-#ifdef WIN32
-
 double doGetYACprice()
 {
     // first call gets BTC/YAC ratio
@@ -263,7 +260,8 @@ Value getYACprice(const Array& params, bool fHelp)
     return sTemp;
 }
 
-#ifdef _MSC_VER
+#ifdef WIN32
+    #ifdef _MSC_VER
 bool 
     isThisInGMT( time_t & tBlock, struct tm  &aTimeStruct )
 {
@@ -291,7 +289,7 @@ bool
     //else //_localtime64_s() errored     
     return fIsGMT;
 }
-#endif
+    #endif
 
 Value getcurrentblockandtime(const Array& params, bool fHelp)
 {
@@ -319,7 +317,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
     time_t 
         tBlock = block.GetBlockTime();
 
-#ifdef _MSC_VER
+    #ifdef _MSC_VER
     char 
         buff[30];
 
@@ -346,7 +344,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
     }
     //else //_localtime64_s() errored     
 **********************/
-#else
+    #else
     struct tm
         *paTimeStruct,
         *pgmTimeStruct;
@@ -380,7 +378,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
         fIsGMT = false;
         return strS;
     }
-#endif
+    #endif
     if( fIsGMT )// for GMT or having errored trying to convert from GMT
     {
         std::string
@@ -397,7 +395,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
         return strS;
     }    
     // let's cook up local time
-#ifdef _MSC_VER
+    #ifdef _MSC_VER
     asctime_s( buff, sizeof(buff), &aTimeStruct );
     buff[ 24 ] = '\0';      // let's wipe out the \n
     printf( //"Local Time: "
@@ -419,7 +417,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
                          , 
                          buff
                         );
-#else
+    #else
     pbuff = asctime( &aTimeStruct );
     if( '\n' == pbuff[ 24 ] )
         pbuff[ 24 ] = '\0';
@@ -440,7 +438,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
                      , 
                      pbuff
                     );
-#endif
+    #endif
     return strS;
 }
 #endif
@@ -603,3 +601,6 @@ Value getcheckpoint(const Array& params, bool fHelp)
 
     return result;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -205,6 +205,17 @@ double doGetYACprice()
         throw runtime_error( "getYACprice\n" "Could not get page 1?" );
         return dUSDperYACprice;
     }
+    if (fPrintToConsole) 
+    {
+        printf(
+                "\n"
+                "b/y %.8lf"
+                "\n"
+                "\n"
+                , dPriceRatio
+              );
+    }
+
     //else    //OK, now we have YAC/BTC (Cryptsy's terminology), really BTC/YAC
     dBTCtoYACprice = dPriceRatio;
     sDestination = "";

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -14,7 +14,6 @@
 
 using namespace json_spirit;
 
-//using namespace std;
 using std::runtime_error;
 using std::string;
 
@@ -227,3 +226,6 @@ Value dumpwallet(const Array& params, bool fHelp)
 
     return Value::null;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -17,7 +17,6 @@
 
 using namespace json_spirit;
 
-//using namespace std;
 using std::vector;
 using std::runtime_error;
 using std::map;
@@ -577,4 +576,6 @@ Value submitblock(const Array& params, bool fHelp)
 
     return Value::null;
 }
-
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -17,7 +17,6 @@
 
 using namespace json_spirit;
 
-//using namespace std;
 using std::runtime_error;
 using std::vector;
 using std::list;
@@ -392,3 +391,6 @@ Value getnettotals(const Array& params, bool fHelp)
     obj.push_back(Pair("timemillis", static_cast<boost::int64_t>(GetTimeMillis())));
     return obj;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -22,7 +22,6 @@ using namespace boost;
 using namespace boost::assign;
 using namespace json_spirit;
 
-//using namespace std;
 using std::vector;
 using std::runtime_error;
 using std::map;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -16,7 +16,6 @@
 
 using namespace json_spirit;
 
-//using namespace std;
 using std::runtime_error;
 using std::string;
 using std::map;
@@ -1935,3 +1934,6 @@ Value makekeypair(const Array& params, bool fHelp)
     result.push_back(Pair("PublicKey", HexStr(key.GetPubKey().Raw())));
     return result;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -21,7 +21,7 @@
 //#include "util.h"
 
 using namespace boost;
-//using namespace std;
+
 using std::vector;
 using std::runtime_error;
 using std::map;
@@ -1032,14 +1032,14 @@ bool EvalScript(
                     CScript scriptCode(pbegincodehash, pend);
 
                     // Drop the signatures, since there's no way for a signature to sign itself
-                    for (int k = 0; k < nSigsCount; k++)
+                    for (int k = 0; k < nSigsCount; ++k)
                     {
-                        valtype& vchSig = stacktop(-isig-k);
-                        scriptCode.FindAndDelete(CScript(vchSig));
+                        valtype& vchSig = stacktop(-isig - k);
+                        scriptCode.FindAndDelete( CScript( vchSig ) );
                     }
 
                     bool fSuccess = true;
-                    while (fSuccess && nSigsCount > 0)
+                    while (fSuccess && (nSigsCount > 0))
                     {
                         valtype& vchSig    = stacktop(-isig);
                         valtype& vchPubKey = stacktop(-ikey);
@@ -1058,11 +1058,11 @@ bool EvalScript(
 
                         if (fOk) 
                         {
-                            isig++;
-                            nSigsCount--;
+                            ++isig;
+                            --nSigsCount;
                         }
-                        ikey++;
-                        nKeysCount--;
+                        ++ikey;
+                        --nKeysCount;
 
                         // If there are more signatures left than keys left,
                         // then too many signatures have failed
@@ -1418,8 +1418,7 @@ bool Solver(
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
 
         if (!fUseOld044Rules)
-        {
-            // Empty, provably prunable, data-carrying output
+        {   // Empty, provably prunable, data-carrying output
             mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA));
         }
     }
@@ -1518,15 +1517,13 @@ bool Solver(
             else if (opcode2 == OP_SMALLDATA)   // this is different from 0.4.4
             {
                 if (!fUseOld044Rules)
-                {
-                    // small pushdata, <= 80 bytes
+                {   // small pushdata, <= 80 bytes
                     if (vch1.size() > 80)
                         break;
                 }
             }
-            else if (opcode1 != opcode2 || vch1 != vch2)
-            {
-                // Others must match exactly
+            else if ((opcode1 != opcode2) || (vch1 != vch2))
+            {   // Others must match exactly
                 break;
             }
         }

--- a/src/scrypt.cpp
+++ b/src/scrypt.cpp
@@ -69,13 +69,13 @@ uint256 scrypt_nosalt(const void* input, size_t inputlen, void *scratchpad)
 }
 
 
-uint256 scrypt(
-               const void* data, 
-               size_t datalen, 
-               const void* salt,
-               size_t saltlen, 
-               void *scratchpad
-              )
+static uint256 scrypt_SHA256(
+                             const void* data, 
+                             size_t datalen, 
+                             const void* salt,
+                             size_t saltlen, 
+                             void *scratchpad
+                            )
 {
     unsigned int 
         *V;
@@ -83,6 +83,7 @@ uint256 scrypt(
         X[ 32 ];
     uint256 
         result = 0;
+
     V = (unsigned int *)(((uintptr_t)(scratchpad) + 63) & ~ (uintptr_t)(63));
 
     PBKDF2_SHA256((const uint8_t*)data, datalen, (const uint8_t*)salt, saltlen, 1, (uint8_t *)X, 128);
@@ -109,7 +110,7 @@ void scrypt_hash(const void* input, size_t inputlen, ::uint32_t *res, unsigned c
 uint256 scrypt_salted_hash(const void* input, size_t inputlen, const void* salt, size_t saltlen)
 {
     unsigned char scratchpad[SCRYPT_BUFFER_SIZE];
-    return scrypt(input, inputlen, salt, saltlen, scratchpad);
+    return scrypt_SHA256(input, inputlen, salt, saltlen, scratchpad);
 }
 
 uint256 scrypt_salted_multiround_hash(const void* input, size_t inputlen, const void* salt, size_t saltlen, const unsigned int nRounds)
@@ -213,3 +214,6 @@ unsigned int scanhash_scrypt(
     }
     return UINT_MAX;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -25,7 +25,8 @@
 #undef __USE_MINGW_ANSI_STDIO // This constant forces MinGW to conduct stupid behavior
 #endif
 #ifdef _MSC_VER
-//#include "../MSVC/include/inttypes.h"
+    #include "stdint.h"
+    #include "inttypes.h"
     #include "JustInCase.h"
 #else
 #include <inttypes.h>

--- a/src/stun.cpp
+++ b/src/stun.cpp
@@ -54,6 +54,9 @@
 
 #include "ministun.h"
 
+#include "sync.h"
+//extern CCriticalSection cs_net;
+
 extern int GetRandInt(int nMax);
 extern uint64_t GetRand(uint64_t nMax);
 
@@ -272,7 +275,11 @@ static int StunRequest2(int sock, struct sockaddr_in *server, struct sockaddr_in
 } // StunRequest2
 
 /*---------------------------------------------------------------------*/
-static int StunRequest(const char *host, uint16_t port, struct sockaddr_in *mapped) {
+static int StunRequest(const char *host, uint16_t port, struct sockaddr_in *mapped) 
+{
+//    LOCK(cs_net);
+    {
+
     struct hostent *hostinfo = gethostbyname(host);
     if(hostinfo == NULL)
         return -1;
@@ -300,6 +307,7 @@ static int StunRequest(const char *host, uint16_t port, struct sockaddr_in *mapp
     closesocket(sock);
 #endif
     return rc;
+    }
 } // StunRequest
 
 /*---------------------------------------------------------------------*/

--- a/src/timestamps.h
+++ b/src/timestamps.h
@@ -1,3 +1,4 @@
+
 #ifndef BITCOIN_TIMESTAMPS_H
 #define BITCOIN_TIMESTAMPS_H
 
@@ -21,7 +22,9 @@ static const unsigned int
   //nSep_01_2016 = 1472688000U,
   //nJul_16_2016 = 1468654496U,
   //nApr_01_2016 = 1459468800U,
-    YACOIN_2016_SWITCH_TIME = nJan_01_2017;
+    nConstantly_changing_date = nJan_01_2017, 
+
+    YACOIN_NEW_LOGIC_SWITCH_TIME = nConstantly_changing_date;
 // we should set the above value as given to match the future time we expect 
 // all nodes will have upgraded and "caught up".  
 // I believe this will create various blocks, therefore branches, forks, that 

--- a/src/txdb-bdb.cpp
+++ b/src/txdb-bdb.cpp
@@ -26,7 +26,6 @@
 
 using namespace boost;
 
-//using namespace std;
 using std::string;
 using std::runtime_error;
 using std::make_pair;
@@ -510,5 +509,8 @@ bool CTxDB::LoadBlockIndexGuts()
 
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif
 #endif
 

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -26,7 +26,6 @@
 
 using namespace boost;
 
-//using namespace std;
 using std::string;
 using std::runtime_error;
 using std::make_pair;
@@ -686,6 +685,8 @@ bool CTxDB::LoadBlockIndex()
     #endif
 #endif
 
+// <<<<<<<<<
+
 #ifdef WIN32
     if (fPrintToConsole) 
         (void)printf( "Sorting by height...\n" );        
@@ -984,4 +985,7 @@ bool CTxDB::LoadBlockIndex()
 
     return true;
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,7 +63,6 @@ namespace boost {
 #include <execinfo.h>
 #endif
 
-//using namespace std;  // testing this change
 using std::map;
 using std::string;
 using std::vector;
@@ -76,6 +75,8 @@ map<string, string> mapArgs;
 map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
 bool fDebugNet = false;
+bool fTestNetNewLogic = false;
+::int32_t nTestNetNewLogicBlockNumber;
 bool fPrintToConsole = false;
 bool fPrintToDebugger = false;
 bool fRequestShutdown = false;
@@ -622,11 +623,12 @@ int64_t GetArg(const std::string& strArg, int64_t nDefault)
 
 bool GetBoolArg(const std::string& strArg, bool fDefault)
 {
-    if (mapArgs.count(strArg))
-    {
-        if (mapArgs[strArg].empty())
-            return true;
-        return (atoi(mapArgs[strArg]) != 0);
+    if (mapArgs.count(strArg))                  // there is/are an argument(s)
+    {                                           // i.e an = sign
+        if (mapArgs[strArg].empty())            // if nothing
+            return true;                        // say true
+        // shouldn't we also test for true or false?!
+        return (atoi(mapArgs[strArg]) != 0);    // if integer not 0 then true
     }
     return fDefault;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -160,6 +160,8 @@ extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
 extern bool fDebugNet;
+extern bool fTestNetNewLogic;
+extern ::int32_t nTestNetNewLogicBlockNumber;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugger;
 extern bool fRequestShutdown;
@@ -259,11 +261,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 void AddTimeData(const CNetAddr& ip, ::int64_t nTime);
 void runCommand(std::string strCommand);
 
-
-
-
-
-
+extern bool HaveWeSwitchedToNewLogicRules( bool &fUsingOld044Rules );   // in main.cpp
 
 
 inline std::string i64tostr(::int64_t n)

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -8,8 +8,8 @@
 
 #define DISPLAY_VERSION_MAJOR       0
 #define DISPLAY_VERSION_MINOR       4
-#define DISPLAY_VERSION_REVISION    6
-#define DISPLAY_VERSION_BUILD       22
+#define DISPLAY_VERSION_REVISION    8   
+#define DISPLAY_VERSION_BUILD       01
 #define DISPLAY_VERSION_TESTING     1
 
 const int

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -9,7 +9,7 @@
 #define DISPLAY_VERSION_MAJOR       0
 #define DISPLAY_VERSION_MINOR       4
 #define DISPLAY_VERSION_REVISION    8   
-#define DISPLAY_VERSION_BUILD       01
+#define DISPLAY_VERSION_BUILD       03
 #define DISPLAY_VERSION_TESTING     1
 
 const int
@@ -48,16 +48,18 @@ const std::string
 //  "YAC-v" DO_STRINGIZE(maj) "." DO_STRINGIZE(min) "." DO_STRINGIZE(rev)
 //    DO_STRINGIZE(maj) \
 
-#define BUILD_DESC_INFO(maj,min,rev) \
+#define BUILD_DESC_INFO(maj,min,rev,build) \
     "YAC-v" \
     DO_STRINGIZE(maj) \
     "." \
     DO_STRINGIZE(min) \
     "." \
-    DO_STRINGIZE(rev)
+    DO_STRINGIZE(rev) \
+    "." \
+    DO_STRINGIZE(build)
 
 #ifndef BUILD_DESC
-#define BUILD_DESC BUILD_DESC_INFO(DISPLAY_VERSION_MAJOR, DISPLAY_VERSION_MINOR, DISPLAY_VERSION_REVISION)
+#define BUILD_DESC BUILD_DESC_INFO(DISPLAY_VERSION_MAJOR, DISPLAY_VERSION_MINOR, DISPLAY_VERSION_REVISION,DISPLAY_VERSION_BUILD)
 #endif
 
 #ifndef BUILD_DATE

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -20,7 +20,6 @@
 
 #include "main.h"
 
-//using namespace std;  // testing this change
 using std::list;
 using std::pair;
 using std::vector;
@@ -1589,13 +1588,12 @@ int64_t CWallet::GetStake() const
            )
         {
             if(
-               //fTestNet ||
-               (pcoin->nTimeReceived < YACOIN_2016_SWITCH_TIME) && !fTestNet // probably should be for all times!
+               fUseOld044Rules
               )
             {
-                nTotal += CWallet::GetDebit(*pcoin, MINE_ALL);
+                nTotal += CWallet::GetDebit(*pcoin, MINE_ALL );
             }
-            else
+            else   // fTestnet || (pcoin->nTimeReceived >= YACOIN_NEW_LOGIC_SWITCH_TIME)
             {
               //nTotal += CWallet::GetDebit(*pcoin, MINE_ALL);  //<<<<<<<<<<<<<<<< test
                 nTotal += CWallet::GetCredit(*pcoin, MINE_ALL);
@@ -3513,7 +3511,8 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const
     // map in which we'll infer heights of other keys
     CBlockIndex                                 // if this is one day in btc? then what for yac??
       //*pindexMax = FindBlockByHeight(std::max(0, nBestHeight - 144)); // the tip can be reorganised; use a 144-block safety margin
-        *pindexMax = FindBlockByHeight(std::max(0, nBestHeight - (int)nOnedayOfAverageBlocks)); // the tip can be reorganised; use a 144-block safety margin
+        *pindexMax = FindBlockByHeight(std::max(0, nBestHeight
+         - (int)nOnedayOfAverageBlocks)); // the tip can be reorganised; use a 144-block safety margin
 
     std::map<CKeyID, CBlockIndex*> mapKeyFirstBlock;
     std::set<CKeyID> setKeys;
@@ -3600,3 +3599,6 @@ void CWallet::ClearOrphans()
     for(list<uint256>::const_iterator it = orphans.begin(); it != orphans.end(); ++it)
         EraseFromWallet(*it);
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -25,7 +25,6 @@
 
 using namespace boost;
 
-//using namespace std;
 using std::list;
 using std::string;
 using std::pair;
@@ -941,3 +940,6 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename)
 {
     return CWalletDB::Recover(dbenv, filename, false);
 }
+#ifdef _MSC_VER
+    #include "msvc_warnings.pop.h"
+#endif


### PR DESCRIPTION
1. The call to TransactionRecord::showTransaction() in
transactiontablemodel.cpp
updateWallet() seems to ignore minted blocks after the "switch over"
date, unless
I'm misreading something?  See comments I added in the code, and
changes.
The output looks the same and correct to me.

2. I still think we should use our own ports not bitcoins!  So I changed
the Qt help
message string in bitcoinstrings.cpp on RPC ports.

3. I'm still trying to restore the NVC Qt code to differentiate between
minted and mined
coinbase transactions in transactionview.cpp, since all the mining code
was removed
beforehand!  Perhaps others can complete the task.  ATM, minted blocks
are shown
as mined.  And there is no real mined icon.  And the terminology is
scrambled,
since mining was abadoned, minting is called mined throughout the code,
yuck!
I have tried to change it to the correct terminology, where I have added
or changed code.
Code I haven't changed, or haven't seen, or haven't understood, I've
left alone!
Though it should be changed too!

4. I've added a new .conf item, a boolean 'testnetNewLogic' to trigger
Matjaz's new logic,
which for the moment, can only be enabled it TestNet mode.  This can
hold off the
old implicit date time switch 'YACOIN_NEW_LOGIC_SWITCH_TIME' in
timestamps.h
I found it silly to keep changing it and recompiling, which would cause
a release of
new exes needlessly.  Also, block times are not the same +/- seconds or
whatever
across the net.
I had thought of the bitcoin idea of median time past, see
'GetMedianTimePast()' in main.h,
but since it uses the undocumented, uncommented magic, contextually
challenged naked
number, identical to Bitcoin's code (of 11 for whatever it's worth) I
thought that if that
was meant to be a roughly 50 minute average block delay in bitcoins
world, then it
would have to be ~100 in Yacoin's world to also be ~50 minutes.  But
since (again!) there
is no documentation, anywhere, I thought it would be better to just
leave it to
someone who knows(?), so I went the above route.  Also there is a
companion .conf item,
a number 'testnetnewlogicblocknumber', which is read after
'LoadBlockIndex()' in init.cpp,
and is set to the best block height 'pindexBest->nHeight' unless the
.conf file sets it to
something else.  The code then immediately calls
'HaveWeSwitchedToNewLogicRules()' to decide
whether or not to switch to new logic, or not.  This way, we can turn on
new logic testing,
in TestNet at the moment, on any Testnet block we want, without
recompiling.  We can further,
when we are happy with the new logic, change the guts of that function
and turn the new logic
on in MainNet too!!  One change all in one place.

5. I have removed the global namespace polluting 'using namespace std;'
from the code, and
replaced it with appropriate using 'using std::string;', etc. phrases,
which at least
explicitly states which std::functions one is adding to that files
global namespace.  If
you research this you wil find the preponderance of evidence is to not
use it.

6.  Added, for completeness, not mandatory, unless .cpp files are
nested, etc., the end of file
#ifdef _MSC_VER
#include "msvc_warnings.pop.h"
#endif
to those files that should have had it, which is a lot!

7.  In main.cpp and elsewhere, tried to replace all the tests for new
logic with one boolean,
'fUsingOld044Rules' to make it clearer what we are doing, and where we
have 'old' 0.4.4 and
'new' Matjaz's logic.

There are places I'm not sure how things should go!  E.g. lines 3264,
3389 on main.cpp  The
code seems to work in Testnet and MainNet so I don't know?  Others
should look at it
with more 'context' than I can bring to the issue!!

8. Back to an old issue I asked about and got no response, the
'CWallet::GetStake()' in wallet.cpp,
issue of how to display the stake of minted coins in the transaction
display of Qt.

It seems to have been wrong since the first NVC 0.4.5 and all following
versions.  I believe it
has to do with the fact that the mining code was removed, the teminology
wasn't changed, and
we YAC-ers use both minting and mining and well you get the idea. :)
You see it in the
transaction display list in Qt.  It always was wrong and didn't match
the old 0.4.4 list, but
since the code was changed so much, and is so Qt obscure and
undocumented, (where have I heard
that before [lol]) I leave to the Qt-ers with more time than I have, to
fix it!

9. I put a comment, actually many in 'GetBoolArg()' in util.cpp since I
found it to be such a
poor rendition of 'get a boolean argument for this name'.  Come on, has
to be 0 if it exists!
And crashes (!!!!) if it is just named with no =  And returns true if
unassigned, i.e "junk =".
And return false on "junk = true" (rotflmao).  Anyway, I put in some
suggestions.  I think that
just because bitcoin still uses this (and pollutes the global namespace)
after 7 years, doesn't
mean we should follow along like sheep.  We can do better.

Think of how much clearer the .conf file can be if named boolean flags
are actually set to true
or false!  And be backward (which it really is!) compatible with the
junky code that is there now.
End of sermon.

10. In script.cpp, line 1035 and elsewhere, I try to show that post
increment is bad form in loop
variables, especially if they are not simple data types, and even if
they are!!
Technically a compiler hint to not load the value anywhere, register,
location, etc.

11. The code in netbase.cpp is more in line with the code in the latest
bitcoin sources.

12. In price.cpp, line 305, I'm guessing how to do linux code, but I
think it should work! Test
and see if getyacprice works for you?